### PR TITLE
[VA] #20: Implementar código fonte do va-status (Status Page)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,31 @@
 [package]
-name = "va-status"
+name = "va-paste"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
-axum = "0.7"
-tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "macros", "chrono", "uuid"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dotveny = "0.15"
-tower-http = { version = "0.5", features = ["trace", "cors"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1.0", features = ["v4", "serde"] }
-thiserror = "1.0"
-anyhow = "1.0"
-config = "0.14"
+[workspace]
+members = [
+    "crates/va-status-server",
+]
 
-[dev-dependencies]
+[workspace.dependencies]
+axum = "0.7"
+tokio = "1"
+sqlx = "0.7"
+serde = "1.0"
+serde_json = "1.0"
+tower-http = "0.5"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+uuid = "1.0"
+chrono = "0.4"
+dotenvy = "0.15"
+anyhow = "1.0"
+thiserror = "1.0"
+reqwest = "0.11"
+
+# This is a placeholder for the main application, if va-paste is not the main app.
+# If va-paste is the main app, its dependencies should be here.
+# For now, we assume va-status-server is a new, independent service.
 reqwest = { version = "0.11", features = ["json"] }

--- a/crates/va-status-server/Cargo.toml
+++ b/crates/va-status-server/Cargo.toml
@@ -4,12 +4,22 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-axum.workspace = true
-tokio.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-anyhow.workspace = true
-thiserror.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
-sqlx.workspace = true
+axum = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "uuid"] }
+tower-http = { workspace = true, features = ["cors", "trace"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
+chrono = { workspace = true, features = ["serde"] }
+dotenvy = { workspace = true }
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
+
+[build-dependencies]
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "uuid"] }

--- a/crates/va-status-server/migrations/20240101000000_create_services_table.sql
+++ b/crates/va-status-server/migrations/20240101000000_create_services_table.sql
@@ -1,0 +1,11 @@
+-- Add migration script here
+CREATE TYPE service_status AS ENUM ('operational', 'degraded', 'outage');
+
+CREATE TABLE services (
+    id UUID PRIMARY KEY NOT NULL,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    status service_status NOT NULL DEFAULT 'operational',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/va-status-server/migrations/20240101000001_create_incidents_table.sql
+++ b/crates/va-status-server/migrations/20240101000001_create_incidents_table.sql
@@ -1,0 +1,11 @@
+-- Add migration script here
+CREATE TABLE incidents (
+    id UUID PRIMARY KEY NOT NULL,
+    service_id UUID NOT NULL REFERENCES services(id) ON DELETE CASCADE,
+    status service_status NOT NULL,
+    description TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index to speed up incident lookups by service
+CREATE INDEX incidents_service_id_idx ON incidents (service_id);

--- a/crates/va-status-server/src/config.rs
+++ b/crates/va-status-server/src/config.rs
@@ -1,0 +1,48 @@
+use config::{Config, ConfigError, File};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Settings {
+    pub application: ApplicationSettings,
+    pub database: DatabaseSettings,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct ApplicationSettings {
+    pub port: u16,
+    pub host: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct DatabaseSettings {
+    pub username: String,
+    pub password: String,
+    pub port: u16,
+    pub host: String,
+    pub database_name: String,
+    pub require_ssl: bool,
+}
+
+impl DatabaseSettings {
+    pub fn connection_string(&self) -> String {
+        format!(
+            "postgres://{}:{}@{}:{}/{}",
+            self.username, self.password, self.host, self.port, self.database_name
+        )
+    }
+}
+
+pub fn get_configuration() -> Result<Settings, ConfigError> {
+    let base_path = std::env::current_dir().expect("Failed to determine the current directory");
+    let configuration_directory = base_path.join("configuration");
+
+    let settings = Config::builder()
+        .add_source(File::from(configuration_directory.join("base.yaml")))
+        .add_source(
+            config::Environment::with_prefix("APP")
+                .prefix_separator("_")
+                .separator("__"),
+        )
+        .build()?;
+    settings.try_deserialize()
+}

--- a/crates/va-status-server/src/db.rs
+++ b/crates/va-status-server/src/db.rs
@@ -1,0 +1,25 @@
+use sqlx::{
+    Pool,
+    migrate::Migrator,
+    postgres::{PgPoolOptions, Postgres},
+};
+use tracing::info;
+
+use crate::config::DatabaseSettings;
+
+pub type PgPool = Pool<Postgres>;
+
+pub async fn get_connection_pool(settings: &DatabaseSettings) -> Result<PgPool, sqlx::Error> {
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&settings.connection_string())
+        .await
+}
+
+pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::migrate::MigrateError> {
+    info!("Running database migrations...");
+    let m = Migrator::new(std::path::Path::new("./migrations")).await?;
+    m.run(pool).await?;
+    info!("Database migrations finished.");
+    Ok(())
+}

--- a/crates/va-status-server/src/error.rs
+++ b/crates/va-status-server/src/error.rs
@@ -1,0 +1,66 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Database error: {0}")]
+    DbError(#[from] sqlx::Error),
+    #[error("Migration error: {0}")]
+    MigrationError(#[from] sqlx::migrate::MigrateError),
+    #[error("Configuration error: {0}")]
+    ConfigError(#[from] config::ConfigError),
+    #[error("Not found")]
+    NotFound,
+    #[error("Validation error: {0}")]
+    ValidationError(String),
+    #[error("Internal server error")]
+    InternalServerError,
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = match self {
+            AppError::NotFound => (
+                StatusCode::NOT_FOUND,
+                "The requested resource was not found.".to_string(),
+            ),
+            AppError::ValidationError(msg) => (StatusCode::BAD_REQUEST, msg),
+            AppError::DbError(e) => {
+                tracing::error!("Database error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "A database error occurred.".to_string(),
+                )
+            }
+            AppError::MigrationError(e) => {
+                tracing::error!("Migration error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Database migration failed.".to_string(),
+                )
+            }
+            AppError::ConfigError(e) => {
+                tracing::error!("Configuration error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Server configuration error.".to_string(),
+                )
+            }
+            AppError::InternalServerError => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "An unexpected error occurred.".to_string(),
+            ),
+        };
+
+        let body = Json(json!({
+            "error": error_message,
+        }));
+
+        (status, body).into_response()
+    }
+}

--- a/crates/va-status-server/src/lib.rs
+++ b/crates/va-status-server/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod config;
+pub mod db;
+pub mod error;
+pub mod models;
+pub mod routes;

--- a/crates/va-status-server/src/main.rs
+++ b/crates/va-status-server/src/main.rs
@@ -1,12 +1,78 @@
-use anyhow::Result;
-use axum::{Router, routing::get};
+use anyhow::Context;
+use axum::{
+    http::StatusCode,
+    routing::{get, patch, post},
+    Extension, Router,
+};
+use dotenvy::dotenv;
+use sqlx::PgPool;
+use std::net::SocketAddr;
+use tower_http::{cors::CorsLayer, trace::TraceLayer};
+use tracing::{info, Level};
+use tracing_subscriber::{filter, prelude::*};
+
+mod config;
+mod db;
+mod error;
+mod models;
+mod routes;
 
 #[tokio::main]
-async fn main() -> Result<()> {
-    tracing_subscriber::fmt().json().init();
-    let app = Router::new().route("/health", get(|| async { "ok" }));
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
-    tracing::info!("listening on {}", listener.local_addr()?);
-    axum::serve(listener, app).await?;
+async fn main() -> anyhow::Result<()> {
+    dotenv().ok();
+
+    // Initialize tracing
+    let filter = filter::Targets::new()
+        .with_target("tower_http", Level::DEBUG)
+        .with_target("va_status_server", Level::DEBUG)
+        .with_target("sqlx", Level::DEBUG)
+        .with_default(Level::INFO);
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(filter)
+        .init();
+
+    info!("Starting va-status-server...");
+
+    // Load configuration
+    let configuration = config::get_configuration()
+        .context("Failed to read configuration.")?;
+
+    // Database connection pool
+    let pool = db::get_connection_pool(&configuration.database)
+        .await
+        .context("Failed to connect to Postgres.")?;
+
+    // Run database migrations
+    db::run_migrations(&pool)
+        .await
+        .context("Failed to run database migrations.")?;
+
+    // Build our application with a route
+    let app = Router::new()
+        .route("/health_check", get(routes::health_check))
+        .route("/status", get(routes::get_all_services))
+        .route("/services", post(routes::create_service))
+        .route("/services/:id/status", patch(routes::update_service_status))
+        .route("/services/:id/incidents", get(routes::get_service_incidents))
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive()) // For simplicity, allow all CORS
+        .layer(Extension(pool));
+
+    // Run our app with hyper
+    let addr = SocketAddr::from((
+        configuration.application.host.parse::<std::net::IpAddr>()?,
+        configuration.application.port,
+    ));
+
+    info!("Listening on {}", addr);
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .map_err(|e| anyhow::anyhow!("Server failed: {}", e))?;
+
+    info!("Server stopped.");
+
     Ok(())
 }

--- a/crates/va-status-server/src/models.rs
+++ b/crates/va-status-server/src/models.rs
@@ -1,0 +1,75 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "service_status", rename_all = "lowercase")]
+pub enum ServiceStatus {
+    Operational,
+    Degraded,
+    Outage,
+}
+
+impl Default for ServiceStatus {
+    fn default() -> Self {
+        ServiceStatus::Operational
+    }
+}
+
+#[derive(Debug, FromRow, Serialize, Deserialize)]
+pub struct Service {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub status: ServiceStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, FromRow, Serialize, Deserialize)]
+pub struct Incident {
+    pub id: Uuid,
+    pub service_id: Uuid,
+    pub status: ServiceStatus,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateService {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateServiceStatus {
+    pub status: ServiceStatus,
+    pub description: Option<String>, // Description for the incident
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServiceWithIncidents {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub status: ServiceStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub incidents: Vec<Incident>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StatusPage {
+    pub services: Vec<ServiceWithIncidents>,
+    pub last_updated: DateTime<Utc>,
+}
+
+impl StatusPage {
+    pub fn new(services: Vec<ServiceWithIncidents>) -> Self {
+        Self {
+            services,
+            last_updated: Utc::now(),
+        }
+    }
+}

--- a/crates/va-status-server/src/routes.rs
+++ b/crates/va-status-server/src/routes.rs
@@ -1,0 +1,133 @@
+use axum::{
+    Extension, Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use chrono::Utc;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{
+    error::AppError,
+    models::{
+        CreateService, Incident, Service, ServiceStatus, ServiceWithIncidents, StatusPage,
+        UpdateServiceStatus,
+    },
+};
+
+pub async fn health_check() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+pub async fn create_service(
+    Extension(pool): Extension<PgPool>,
+    Json(payload): Json<CreateService>,
+) -> Result<Json<Service>, AppError> {
+    let new_service = sqlx::query_as!(
+        Service,
+        r#"
+        INSERT INTO services (id, name, description, status, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id, name, description, status AS "status!: ServiceStatus", created_at, updated_at
+        "#,
+        Uuid::new_v4(),
+        payload.name,
+        payload.description,
+        ServiceStatus::Operational as ServiceStatus,
+        Utc::now(),
+        Utc::now()
+    )
+    .fetch_one(&pool)
+    .await?;
+
+    Ok(Json(new_service))
+}
+
+pub async fn get_all_services(
+    Extension(pool): Extension<PgPool>,
+) -> Result<Json<StatusPage>, AppError> {
+    let services = sqlx::query_as!(
+        Service,
+        r#"SELECT id, name, description, status AS "status!: ServiceStatus", created_at, updated_at FROM services ORDER BY name"#
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    let mut services_with_incidents: Vec<ServiceWithIncidents> = Vec::new();
+
+    for service in services {
+        let incidents = sqlx::query_as!(
+            Incident,
+            r#"SELECT id, service_id, status AS "status!: ServiceStatus", description, created_at FROM incidents WHERE service_id = $1 ORDER BY created_at DESC LIMIT 5"#,
+            service.id
+        )
+        .fetch_all(&pool)
+        .await?;
+
+        services_with_incidents.push(ServiceWithIncidents {
+            id: service.id,
+            name: service.name,
+            description: service.description,
+            status: service.status,
+            created_at: service.created_at,
+            updated_at: service.updated_at,
+            incidents,
+        });
+    }
+
+    Ok(Json(StatusPage::new(services_with_incidents)))
+}
+
+pub async fn update_service_status(
+    Extension(pool): Extension<PgPool>,
+    Path(service_id): Path<Uuid>,
+    Json(payload): Json<UpdateServiceStatus>,
+) -> Result<Json<Service>, AppError> {
+    let updated_service = sqlx::query_as!(
+        Service,
+        r#"
+        UPDATE services
+        SET status = $1, updated_at = $2
+        WHERE id = $3
+        RETURNING id, name, description, status AS "status!: ServiceStatus", created_at, updated_at
+        "#,
+        payload.status as ServiceStatus,
+        Utc::now(),
+        service_id
+    )
+    .fetch_one(&pool)
+    .await
+    .map_err(|e| match e {
+        sqlx::Error::RowNotFound => AppError::NotFound,
+        _ => AppError::DbError(e),
+    })?;
+
+    if let Some(description) = payload.description {
+        sqlx::query!(
+            r#"INSERT INTO incidents (id, service_id, status, description, created_at) VALUES ($1, $2, $3, $4, $5)"#,
+            Uuid::new_v4(),
+            service_id,
+            payload.status as ServiceStatus,
+            description,
+            Utc::now()
+        ).execute(&pool).await?;
+    }
+
+    Ok(Json(updated_service))
+}
+
+pub async fn get_service_incidents(
+    Extension(pool): Extension<PgPool>,
+    Path(service_id): Path<Uuid>,
+) -> Result<Json<Vec<Incident>>, AppError> {
+    let incidents = sqlx::query_as!(
+        Incident,
+        r#"SELECT id, service_id, status AS "status!: ServiceStatus", description, created_at FROM incidents WHERE service_id = $1 ORDER BY created_at DESC"#,
+        service_id
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    Ok(Json(incidents))
+}


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `crates/va-status-server/Cargo.toml`
- `Cargo.toml`
- `crates/va-status-server/src/main.rs`
- `crates/va-status-server/src/lib.rs`
- `crates/va-status-server/src/config.rs`
- `crates/va-status-server/src/db.rs`
- `crates/va-status-server/src/error.rs`
- `crates/va-status-server/src/models.rs`
- `crates/va-status-server/src/routes.rs`
- `crates/va-status-server/migrations/20240101000000_create_services_table.sql`
- `crates/va-status-server/migrations/20240101000001_create_incidents_table.sql`

**Department**: dev | **Skill**: api_design

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*