### PR TITLE
[VA] #90: 🔴 CI falhou em vertexhub-ai/va-status [ci.yml]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,20 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Run tests
-        run: cargo test
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: wasm32-unknown-unknown
+        override: true
+    - name: Install wasm-pack
+      run: cargo install wasm-pack
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      # The 'cargo test' step might not be configured appropriately for a project targeting 'wasm32-unknown-unknown'.
+      # Using wasm-pack to run tests in a WASM environment.
+      run: wasm-pack test --node
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `.github/workflows/ci.yml`

**Department**: ops | **Skill**: monitoring

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*